### PR TITLE
Upgrading streamroller dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "on-finished": "2.3.0",
     "request-ip": "1.2.3",
-    "streamroller": "0.3.0"
+    "streamroller": "2.2.2"
   },
   "devDependencies": {
     "chai": "3.5.x",


### PR DESCRIPTION
There's a vulnerability in a downstream dependency: https://npmjs.com/advisories/534